### PR TITLE
update node-fetch 2.6.0->2.6.1 [AS-824]

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1772,12 +1772,7 @@ neo-async@^2.6.0:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
-node-fetch@^2.3.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
-  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
-
-node-fetch@^2.6.1:
+node-fetch@^2.6.1, node-fetch@^2.3.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==


### PR DESCRIPTION
We have a transitive dependency:
```
@google-cloud#datastore -> google-gax -> google-auth-library -> gaxios -> node-fetch
```
that pulls in node-fetch version 2.6.0. 

CVE-2020-15168 requires that we use node-fetch 2.6.1 (or 3.0.0-beta.9):
* https://github.com/advisories/GHSA-w7rc-rwvf-8q5r
* https://nvd.nist.gov/vuln/detail/CVE-2020-15168

This PR updates the transitive dependency from node-fetch 2.6.0 -> 2.6.1.

https://github.com/node-fetch/node-fetch/blob/main/docs/CHANGELOG.md#v261 shows the changelog for 2.6.0 -> 2.6.1 to be:

> v2.6.1
> This is an important security release. It is strongly recommended to update as soon as possible.
> 
> Fix: honor the size option after following a redirect.

**NB:** Dependabot is not creating a PR for this issue, it may have a problem detecting it. However, `yarn audit` shows the CVE warning, and dependabot shows a security alert; it's just not making a PR. So I'm doing it manually.